### PR TITLE
feat: 포인트 적립 구현시 필요한 SQL은 인덱스를 타도록 수정

### DIFF
--- a/src/main/java/com/report/triple/domain/point/entity/Point.java
+++ b/src/main/java/com/report/triple/domain/point/entity/Point.java
@@ -11,11 +11,11 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = @Index(name = "idx_point", columnList = "userId", unique = true))
 public class Point extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "point_id")
     private Long id;
-    @Column(unique = true)
     private String userId;
     private int totalPoint;
 


### PR DESCRIPTION
## 상세
실행 계획을 통해 인덱스를 타는지 확인하였음

기존에 userId 컬럼에 unique를 걸어놓아서 인덱스가 자동으로 생성 되었음
Mysql 은 인덱스 없이 유니크 제약조건만 걸 방법이 없으므로.
-> 보기 편하게 바꾸었음

참고 https://velog.io/@jsj3282/19.-%EC%9C%A0%EB%8B%88%ED%81%AC-%EC%9D%B8%EB%8D%B1%EC%8A%A4

closed #10 